### PR TITLE
Wrap python executable path in quotes

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -60,7 +60,7 @@ env = DefaultEnvironment()
 try:
     import pymcuprog
 except ImportError:
-    env.Execute("$PYTHONEXE -m pip install pymcuprog")
+    env.Execute("\"$PYTHONEXE\" -m pip install pymcuprog")
 
 env.Replace(
     AR="avr-gcc-ar",


### PR DESCRIPTION
In the event that a user has a whitespace character in their home directory name, the shell script is malformed.