### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - name: Install dependencies

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,31 @@
+name: Examples
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        example:
+          - "examples/quty_blinky_asm"
+          - "examples/quty_blinky_asm_bare"
+          - "examples/quty_blinky_c"
+          - "examples/quty_serial_helloworld"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          pip install -U https://github.com/platformio/platformio/archive/develop.zip
+          pio pkg install --global --platform symlink://.
+      - name: Build examples
+        run: |
+          pio run -d ${{ matrix.example }}


### PR DESCRIPTION
Enables free Github Actions to run on this repo to verify that each example is compilable for Windows, Linux and Mac like the [atmelavr repo](https://github.com/platformio/platform-atmelavr/blob/develop/.github/workflows/examples.yml) does.

See example run https://github.com/maxgerhardt/quty/actions/runs/4123077722.